### PR TITLE
update logo url for imbue network

### DIFF
--- a/src/pages/Index.vue
+++ b/src/pages/Index.vue
@@ -406,8 +406,6 @@ export default defineComponent({
             image = `https://raw.githubusercontent.com/TalismanSociety/chaindata/multi-relay-chain-future/0/parathreads/${paraId}/assets/logo.svg`;
           } else if (paraId === 3019) {
             image = `https://resources.acala.network/networks/gm.png`;
-          } else if (paraId === 2121) {
-            image = `https://resources.acala.network/networks/imbue.png`;
           } else {
             image = `https://raw.githubusercontent.com/TalismanSociety/chaindata/multi-relay-chain-future/2/parathreads/${paraId}/assets/logo.svg`;
           }


### PR DESCRIPTION
@gluneau Assets for the imbue network is registered to [polkadot chain data repo](https://github.com/TalismanSociety/chaindata), so now we don't need to fetch the logo from https://resources.acala.network/ .